### PR TITLE
Refactor QTI models into version-specific files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A command-line tool for migrating QTI (Question and Test Interoperability) files
 - **Pipe Support**: Can be used in scripts with stdin/stdout support
 - **Error Handling**: Clear error messages for migration issues
 - **Modular Architecture**: Easy to extend for new QTI versions
+- **Version-Specific Models**: Clean separation of QTI version structures for better maintainability
 
 ## Installation
 
@@ -144,7 +145,16 @@ WARNINGS
 
 The tool is built with a modular architecture:
 
-- **Parser**: Handles parsing of different QTI versions
+- **Parser**: Handles parsing of different QTI versions with version-specific parsers
+  - `qti12.Parser12` for QTI 1.2 documents
+  - `qti21.Parser21` for QTI 2.1/2.2 documents  
+  - `qti30.Parser30` for QTI 3.0 documents
+- **Models**: Version-specific data structures
+  - `models/common.go` - Shared structures (LOM metadata, materials)
+  - `models/qti12.go` - QTI 1.2 specific structures
+  - `models/qti21.go` - QTI 2.1/2.2 specific structures
+  - `models/qti30.go` - QTI 3.0 specific structures
+  - `models/qti.go` - Generic structures for backward compatibility
 - **Preprocessor**: Analyzes documents for migration compatibility
 - **Migrator**: Performs the actual migration transformations
 - **Reporter**: Generates human-readable reports

--- a/internal/parser/factory.go
+++ b/internal/parser/factory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/qti-migrator/internal/parser/qti12"
 	"github.com/qti-migrator/internal/parser/qti21"
+	"github.com/qti-migrator/internal/parser/qti30"
 )
 
 func GetParser(version string) (Parser, error) {
@@ -17,8 +18,7 @@ func GetParser(version string) (Parser, error) {
 	case strings.HasPrefix(version, "2.1") || strings.HasPrefix(version, "2.2"):
 		return qti21.New(), nil
 	case strings.HasPrefix(version, "3.0"):
-		// For now, QTI 3.0 uses same parser as 2.1 since XML structure is similar
-		return qti21.New(), nil
+		return qti30.New(), nil
 	default:
 		return nil, fmt.Errorf("unsupported QTI version: %s", version)
 	}

--- a/internal/parser/factory_test.go
+++ b/internal/parser/factory_test.go
@@ -73,9 +73,9 @@ func TestGetParser_QTI30(t *testing.T) {
 			continue
 		}
 		
-		// QTI 3.0 uses the same parser as 2.1 for now
-		if parser.Version() != "2.1" {
-			t.Errorf("Expected parser version '2.1' for QTI 3.0, got '%s' for input version '%s'", 
+		// QTI 3.0 now has its own parser
+		if parser.Version() != "3.0" {
+			t.Errorf("Expected parser version '3.0' for QTI 3.0, got '%s' for input version '%s'", 
 				parser.Version(), version)
 		}
 	}

--- a/internal/parser/qti12/parser.go
+++ b/internal/parser/qti12/parser.go
@@ -18,7 +18,7 @@ func (p *Parser12) Version() string {
 }
 
 func (p *Parser12) Parse(content []byte) (*models.QTIDocument, error) {
-	var doc models.QTIDocument
+	var doc models.QTIDocument12
 	err := xml.Unmarshal(content, &doc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse QTI 1.2 document: %w", err)
@@ -32,7 +32,16 @@ func (p *Parser12) Parse(content []byte) (*models.QTIDocument, error) {
 		return nil, fmt.Errorf("invalid QTI version for 1.2 parser: %s", doc.Version)
 	}
 
-	return &doc, nil
+	// Convert to generic QTIDocument for backward compatibility
+	genericDoc := &models.QTIDocument{
+		XMLName:    doc.XMLName,
+		Version:    doc.Version,
+		Items:      convertItems12ToGeneric(doc.Items),
+		Assessment: convertAssessment12ToGeneric(doc.Assessment),
+		Metadata:   doc.Metadata,
+	}
+
+	return genericDoc, nil
 }
 
 func isValidQTI12Version(version string) bool {
@@ -42,4 +51,67 @@ func isValidQTI12Version(version string) bool {
 	default:
 		return false
 	}
+}
+
+// Converter functions to transform QTI 1.2 specific types to generic types
+
+func convertItems12ToGeneric(items []models.Item12) []models.Item {
+	genericItems := make([]models.Item, len(items))
+	for i, item := range items {
+		genericItems[i] = models.Item{
+			XMLName:      item.XMLName,
+			Title:        item.Title,
+			Ident:        item.Ident,
+			MaxAttempts:  item.MaxAttempts,
+			Metadata:     item.Metadata,
+			Presentation: item.Presentation,
+			ResponseProc: item.ResponseProc,
+			Feedback:     convertFeedback12ToGeneric(item.Feedback),
+			RubricBlock:  item.RubricBlock,
+		}
+	}
+	return genericItems
+}
+
+func convertAssessment12ToGeneric(assessment *models.Assessment12) *models.Assessment {
+	if assessment == nil {
+		return nil
+	}
+	return &models.Assessment{
+		XMLName:     assessment.XMLName,
+		Title:       assessment.Title,
+		Ident:       assessment.Ident,
+		Sections:    convertSections12ToGeneric(assessment.Sections),
+		Metadata:    assessment.Metadata,
+		Objectives:  assessment.Objectives,
+		RubricBlock: assessment.RubricBlock,
+	}
+}
+
+func convertSections12ToGeneric(sections []models.Section12) []models.Section {
+	genericSections := make([]models.Section, len(sections))
+	for i, section := range sections {
+		genericSections[i] = models.Section{
+			XMLName:  section.XMLName,
+			Title:    section.Title,
+			Ident:    section.Ident,
+			Items:    convertItems12ToGeneric(section.Items),
+			Metadata: section.Metadata,
+		}
+	}
+	return genericSections
+}
+
+func convertFeedback12ToGeneric(feedbacks []models.Feedback12) []models.Feedback {
+	genericFeedbacks := make([]models.Feedback, len(feedbacks))
+	for i, feedback := range feedbacks {
+		genericFeedbacks[i] = models.Feedback{
+			XMLName:  feedback.XMLName,
+			Ident:    feedback.Ident,
+			Title:    feedback.Title,
+			FlowMat:  feedback.FlowMat,
+			Material: feedback.Material,
+		}
+	}
+	return genericFeedbacks
 }

--- a/internal/parser/qti12/parser.go
+++ b/internal/parser/qti12/parser.go
@@ -105,13 +105,7 @@ func convertSections12ToGeneric(sections []models.Section12) []models.Section {
 func convertFeedback12ToGeneric(feedbacks []models.Feedback12) []models.Feedback {
 	genericFeedbacks := make([]models.Feedback, len(feedbacks))
 	for i, feedback := range feedbacks {
-		genericFeedbacks[i] = models.Feedback{
-			XMLName:  feedback.XMLName,
-			Ident:    feedback.Ident,
-			Title:    feedback.Title,
-			FlowMat:  feedback.FlowMat,
-			Material: feedback.Material,
-		}
+		genericFeedbacks[i] = models.Feedback(feedback)
 	}
 	return genericFeedbacks
 }

--- a/internal/parser/qti21/parser.go
+++ b/internal/parser/qti21/parser.go
@@ -153,13 +153,7 @@ func convertTemplateDecl21ToGeneric(decls []models.TemplateDecl21) []models.Temp
 func convertFeedback21ToGeneric(feedbacks []models.Feedback21) []models.Feedback {
 	genericFeedbacks := make([]models.Feedback, len(feedbacks))
 	for i, feedback := range feedbacks {
-		genericFeedbacks[i] = models.Feedback{
-			XMLName:  feedback.XMLName,
-			Ident:    feedback.Ident,
-			Title:    feedback.Title,
-			FlowMat:  feedback.FlowMat,
-			Material: feedback.Material,
-		}
+		genericFeedbacks[i] = models.Feedback(feedback)
 	}
 	return genericFeedbacks
 }

--- a/internal/parser/qti21/parser.go
+++ b/internal/parser/qti21/parser.go
@@ -18,7 +18,7 @@ func (p *Parser21) Version() string {
 }
 
 func (p *Parser21) Parse(content []byte) (*models.QTIDocument, error) {
-	var doc models.QTIDocument
+	var doc models.QTIDocument21
 	err := xml.Unmarshal(content, &doc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse QTI 2.1 document: %w", err)
@@ -32,7 +32,16 @@ func (p *Parser21) Parse(content []byte) (*models.QTIDocument, error) {
 		return nil, fmt.Errorf("invalid QTI version for 2.1 parser: %s", doc.Version)
 	}
 
-	return &doc, nil
+	// Convert to generic QTIDocument for backward compatibility
+	genericDoc := &models.QTIDocument{
+		XMLName:    doc.XMLName,
+		Version:    doc.Version,
+		Items:      convertItems21ToGeneric(doc.Items),
+		Assessment: convertAssessment21ToGeneric(doc.Assessment),
+		Metadata:   doc.Metadata,
+	}
+
+	return genericDoc, nil
 }
 
 func isValidQTI21Version(version string) bool {
@@ -42,4 +51,115 @@ func isValidQTI21Version(version string) bool {
 	default:
 		return false
 	}
+}
+
+// Converter functions to transform QTI 2.1 specific types to generic types
+
+func convertItems21ToGeneric(items []models.Item21) []models.Item {
+	genericItems := make([]models.Item, len(items))
+	for i, item := range items {
+		genericItems[i] = models.Item{
+			XMLName:      item.XMLName,
+			Title:        item.Title,
+			Ident:        item.Ident,
+			MaxAttempts:  item.MaxAttempts,
+			Metadata:     item.Metadata,
+			Presentation: item.Presentation,
+			ResponseProc: item.ResponseProc,
+			ItemBody:     item.ItemBody,
+			ResponseDecl: convertResponseDecl21ToGeneric(item.ResponseDecl),
+			OutcomeDecl:  convertOutcomeDecl21ToGeneric(item.OutcomeDecl),
+			TemplateDecl: convertTemplateDecl21ToGeneric(item.TemplateDecl),
+			Feedback:     convertFeedback21ToGeneric(item.Feedback),
+			RubricBlock:  item.RubricBlock,
+		}
+	}
+	return genericItems
+}
+
+func convertAssessment21ToGeneric(assessment *models.Assessment21) *models.Assessment {
+	if assessment == nil {
+		return nil
+	}
+	return &models.Assessment{
+		XMLName:     assessment.XMLName,
+		Title:       assessment.Title,
+		Ident:       assessment.Ident,
+		Sections:    convertSections21ToGeneric(assessment.Sections),
+		Metadata:    assessment.Metadata,
+		Objectives:  assessment.Objectives,
+		RubricBlock: assessment.RubricBlock,
+	}
+}
+
+func convertSections21ToGeneric(sections []models.Section21) []models.Section {
+	genericSections := make([]models.Section, len(sections))
+	for i, section := range sections {
+		genericSections[i] = models.Section{
+			XMLName:  section.XMLName,
+			Title:    section.Title,
+			Ident:    section.Ident,
+			Items:    convertItems21ToGeneric(section.Items),
+			Metadata: section.Metadata,
+		}
+	}
+	return genericSections
+}
+
+func convertResponseDecl21ToGeneric(decls []models.ResponseDecl21) []models.ResponseDecl {
+	genericDecls := make([]models.ResponseDecl, len(decls))
+	for i, decl := range decls {
+		genericDecls[i] = models.ResponseDecl{
+			XMLName:         decl.XMLName,
+			Identifier:      decl.Identifier,
+			Cardinality:     decl.Cardinality,
+			BaseType:        decl.BaseType,
+			CorrectResponse: (*models.CorrectResponse)(decl.CorrectResponse),
+			Mapping:         (*models.Mapping)(decl.Mapping),
+		}
+	}
+	return genericDecls
+}
+
+func convertOutcomeDecl21ToGeneric(decls []models.OutcomeDecl21) []models.OutcomeDecl {
+	genericDecls := make([]models.OutcomeDecl, len(decls))
+	for i, decl := range decls {
+		genericDecls[i] = models.OutcomeDecl{
+			XMLName:      decl.XMLName,
+			Identifier:   decl.Identifier,
+			Cardinality:  decl.Cardinality,
+			BaseType:     decl.BaseType,
+			DefaultValue: (*models.DefaultValue)(decl.DefaultValue),
+		}
+	}
+	return genericDecls
+}
+
+func convertTemplateDecl21ToGeneric(decls []models.TemplateDecl21) []models.TemplateDecl {
+	genericDecls := make([]models.TemplateDecl, len(decls))
+	for i, decl := range decls {
+		genericDecls[i] = models.TemplateDecl{
+			XMLName:       decl.XMLName,
+			Identifier:    decl.Identifier,
+			Cardinality:   decl.Cardinality,
+			BaseType:      decl.BaseType,
+			ParamVariable: decl.ParamVariable,
+			DefaultValue:  (*models.DefaultValue)(decl.DefaultValue),
+		}
+	}
+	return genericDecls
+}
+
+func convertFeedback21ToGeneric(feedbacks []models.Feedback21) []models.Feedback {
+	genericFeedbacks := make([]models.Feedback, len(feedbacks))
+	for i, feedback := range feedbacks {
+		genericFeedbacks[i] = models.Feedback{
+			XMLName:  feedback.XMLName,
+			Ident:    feedback.Ident,
+			Title:    feedback.Title,
+			FlowMat:  feedback.FlowMat,
+			Material: feedback.Material,
+		}
+	}
+	return genericFeedbacks
 }

--- a/internal/parser/qti30/parser.go
+++ b/internal/parser/qti30/parser.go
@@ -1,0 +1,197 @@
+package qti30
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/qti-migrator/pkg/models"
+)
+
+type Parser30 struct{}
+
+func New() *Parser30 {
+	return &Parser30{}
+}
+
+func (p *Parser30) Version() string {
+	return "3.0"
+}
+
+func (p *Parser30) Parse(content []byte) (*models.QTIDocument, error) {
+	var doc models.QTIDocument30
+	err := xml.Unmarshal(content, &doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse QTI 3.0 document: %w", err)
+	}
+
+	if doc.Version == "" {
+		doc.Version = "3.0"
+	}
+
+	if !isValidQTI30Version(doc.Version) {
+		return nil, fmt.Errorf("invalid QTI version for 3.0 parser: %s", doc.Version)
+	}
+
+	// QTI 3.0 has a completely different structure, so we need to transform it
+	// to the generic format for backward compatibility
+	genericDoc := &models.QTIDocument{
+		XMLName:  xml.Name{Local: "questestinterop"},
+		Version:  doc.Version,
+		Items:    []models.Item{convertItem30ToGeneric(doc)},
+		Metadata: doc.Metadata,
+	}
+
+	return genericDoc, nil
+}
+
+func isValidQTI30Version(version string) bool {
+	switch version {
+	case "3.0", "3.0.0":
+		return true
+	default:
+		return false
+	}
+}
+
+// Converter function to transform a QTI 3.0 document (which is an item) to generic Item
+func convertItem30ToGeneric(doc models.QTIDocument30) models.Item {
+	return models.Item{
+		XMLName:      xml.Name{Local: "item"},
+		Title:        doc.Title,
+		Ident:        doc.Identifier,
+		Metadata:     doc.Metadata,
+		ItemBody:     convertItemBody30ToGeneric(doc.ItemBody),
+		ResponseDecl: convertResponseDecl30ToGeneric(doc.ResponseDeclarations),
+		OutcomeDecl:  convertOutcomeDecl30ToGeneric(doc.OutcomeDeclarations),
+		TemplateDecl: convertTemplateDecl30ToGeneric(doc.TemplateDeclarations),
+		// Note: QTI 3.0 uses modalFeedback instead of itemfeedback
+		Feedback: convertModalFeedback30ToGeneric(doc.ModalFeedback),
+	}
+}
+
+func convertItemBody30ToGeneric(body *models.ItemBody30) *models.ItemBody {
+	if body == nil {
+		return nil
+	}
+	// QTI 3.0 ItemBody has a more flexible structure
+	// For now, we'll create a simple generic ItemBody
+	return &models.ItemBody{
+		XMLName: body.XMLName,
+		// The content needs special handling as it's an interface{} slice in QTI 3.0
+		// This would require more sophisticated conversion based on actual content types
+	}
+}
+
+func convertResponseDecl30ToGeneric(decls []models.ResponseDecl30) []models.ResponseDecl {
+	genericDecls := make([]models.ResponseDecl, len(decls))
+	for i, decl := range decls {
+		genericDecls[i] = models.ResponseDecl{
+			XMLName:      decl.XMLName,
+			Identifier:   decl.Identifier,
+			Cardinality:  decl.Cardinality,
+			BaseType:     decl.BaseType,
+			CorrectResponse: convertCorrectResponse30ToGeneric(decl.CorrectResponse),
+			Mapping:      convertMapping30ToGeneric(decl.Mapping),
+		}
+	}
+	return genericDecls
+}
+
+func convertCorrectResponse30ToGeneric(cr *models.CorrectResponse30) *models.CorrectResponse {
+	if cr == nil {
+		return nil
+	}
+	values := make([]string, len(cr.Value))
+	for i, v := range cr.Value {
+		values[i] = v.Content
+	}
+	return &models.CorrectResponse{
+		XMLName: cr.XMLName,
+		Value:   values,
+	}
+}
+
+func convertMapping30ToGeneric(m *models.Mapping30) *models.Mapping {
+	if m == nil {
+		return nil
+	}
+	entries := make([]models.MapEntry, len(m.MapEntry))
+	for i, e := range m.MapEntry {
+		entries[i] = models.MapEntry{
+			XMLName:     e.XMLName,
+			MapKey:      e.MapKey,
+			MappedValue: e.MappedValue,
+		}
+	}
+	return &models.Mapping{
+		XMLName:      m.XMLName,
+		LowerBound:   m.LowerBound,
+		UpperBound:   m.UpperBound,
+		DefaultValue: m.DefaultValue,
+		MapEntry:     entries,
+	}
+}
+
+func convertOutcomeDecl30ToGeneric(decls []models.OutcomeDecl30) []models.OutcomeDecl {
+	genericDecls := make([]models.OutcomeDecl, len(decls))
+	for i, decl := range decls {
+		genericDecls[i] = models.OutcomeDecl{
+			XMLName:      decl.XMLName,
+			Identifier:   decl.Identifier,
+			Cardinality:  decl.Cardinality,
+			BaseType:     decl.BaseType,
+			DefaultValue: convertDefaultValue30ToGeneric(decl.DefaultValue),
+		}
+	}
+	return genericDecls
+}
+
+func convertDefaultValue30ToGeneric(dv *models.DefaultValue30) *models.DefaultValue {
+	if dv == nil {
+		return nil
+	}
+	// Take the first value for simplicity
+	value := ""
+	if len(dv.Value) > 0 {
+		value = dv.Value[0].Content
+	}
+	return &models.DefaultValue{
+		XMLName: dv.XMLName,
+		Value:   value,
+	}
+}
+
+func convertTemplateDecl30ToGeneric(decls []models.TemplateDecl30) []models.TemplateDecl {
+	genericDecls := make([]models.TemplateDecl, len(decls))
+	for i, decl := range decls {
+		genericDecls[i] = models.TemplateDecl{
+			XMLName:       decl.XMLName,
+			Identifier:    decl.Identifier,
+			Cardinality:   decl.Cardinality,
+			BaseType:      decl.BaseType,
+			ParamVariable: decl.ParamVariable,
+			DefaultValue:  convertDefaultValue30ToGeneric(decl.DefaultValue),
+		}
+	}
+	return genericDecls
+}
+
+func convertModalFeedback30ToGeneric(feedbacks []models.ModalFeedback30) []models.Feedback {
+	genericFeedbacks := make([]models.Feedback, len(feedbacks))
+	for i, feedback := range feedbacks {
+		// Convert modalFeedback to itemfeedback format
+		genericFeedbacks[i] = models.Feedback{
+			XMLName: xml.Name{Local: "itemfeedback"},
+			Ident:   feedback.Identifier,
+			Title:   feedback.Title,
+			Material: &models.Material{
+				MatText: []models.MatText{
+					{
+						Content: feedback.Content,
+					},
+				},
+			},
+		}
+	}
+	return genericFeedbacks
+}

--- a/internal/parser/qti30/parser.go
+++ b/internal/parser/qti30/parser.go
@@ -117,11 +117,7 @@ func convertMapping30ToGeneric(m *models.Mapping30) *models.Mapping {
 	}
 	entries := make([]models.MapEntry, len(m.MapEntry))
 	for i, e := range m.MapEntry {
-		entries[i] = models.MapEntry{
-			XMLName:     e.XMLName,
-			MapKey:      e.MapKey,
-			MappedValue: e.MappedValue,
-		}
+		entries[i] = models.MapEntry(e)
 	}
 	return &models.Mapping{
 		XMLName:      m.XMLName,

--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -1,0 +1,182 @@
+package models
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+// Common metadata structures used across all QTI versions
+
+type Metadata struct {
+	XMLName     xml.Name    `xml:"metadata"`
+	Schema      string      `xml:"schema,omitempty"`
+	SchemaVer   string      `xml:"schemaversion,omitempty"`
+	LOM         *LOM        `xml:"lom,omitempty"`
+	QTIMetadata *QTIMetadata `xml:"qtimetadata,omitempty"`
+}
+
+type QTIMetadata struct {
+	XMLName            xml.Name    `xml:"qtimetadata"`
+	TimeDependent      bool        `xml:"timedependent,omitempty"`
+	Composite          bool        `xml:"composite,omitempty"`
+	InteractionType    string      `xml:"interactiontype,omitempty"`
+	FeedbackType       string      `xml:"feedbacktype,omitempty"`
+	SolutionAvailable  bool        `xml:"solutionavailable,omitempty"`
+	Scoringmode        string      `xml:"scoringmode,omitempty"`
+	ToolName           string      `xml:"toolname,omitempty"`
+	ToolVersion        string      `xml:"toolversion,omitempty"`
+	ToolVendor         string      `xml:"toolvendor,omitempty"`
+}
+
+// LOM (Learning Object Metadata) structures
+
+type LOM struct {
+	XMLName     xml.Name     `xml:"lom"`
+	General     *LOMGeneral  `xml:"general,omitempty"`
+	Lifecycle   *LOMLifecycle `xml:"lifecycle,omitempty"`
+	Technical   *LOMTechnical `xml:"technical,omitempty"`
+	Educational *LOMEducational `xml:"educational,omitempty"`
+	Rights      *LOMRights   `xml:"rights,omitempty"`
+}
+
+type LOMGeneral struct {
+	Identifier  []LOMIdentifier `xml:"identifier,omitempty"`
+	Title       *LOMString      `xml:"title,omitempty"`
+	Language    []string        `xml:"language,omitempty"`
+	Description []LOMString     `xml:"description,omitempty"`
+	Keyword     []LOMString     `xml:"keyword,omitempty"`
+}
+
+type LOMIdentifier struct {
+	Catalog string `xml:"catalog,omitempty"`
+	Entry   string `xml:"entry,omitempty"`
+}
+
+type LOMString struct {
+	Language string `xml:"language,attr,omitempty"`
+	Value    string `xml:",chardata"`
+}
+
+type LOMLifecycle struct {
+	Version     *LOMString      `xml:"version,omitempty"`
+	Status      *LOMVocabulary  `xml:"status,omitempty"`
+	Contribute  []LOMContribute `xml:"contribute,omitempty"`
+}
+
+type LOMVocabulary struct {
+	Source string `xml:"source,omitempty"`
+	Value  string `xml:"value,omitempty"`
+}
+
+type LOMContribute struct {
+	Role   *LOMVocabulary `xml:"role,omitempty"`
+	Entity []string       `xml:"entity,omitempty"`
+	Date   *LOMDateTime   `xml:"date,omitempty"`
+}
+
+type LOMDateTime struct {
+	DateTime    time.Time  `xml:"datetime,omitempty"`
+	Description *LOMString `xml:"description,omitempty"`
+}
+
+type LOMTechnical struct {
+	Format               []string              `xml:"format,omitempty"`
+	Size                 string                `xml:"size,omitempty"`
+	Location             []string              `xml:"location,omitempty"`
+	Requirement          []LOMRequirement      `xml:"requirement,omitempty"`
+	InstallationRemarks  *LOMString            `xml:"installationremarks,omitempty"`
+	OtherPlatformReq     *LOMString            `xml:"otherplatformrequirements,omitempty"`
+	Duration             *LOMDuration          `xml:"duration,omitempty"`
+}
+
+type LOMRequirement struct {
+	OrComposite []LOMOrComposite `xml:"orcomposite,omitempty"`
+}
+
+type LOMOrComposite struct {
+	Type         *LOMVocabulary `xml:"type,omitempty"`
+	Name         *LOMVocabulary `xml:"name,omitempty"`
+	MinVersion   string         `xml:"minimumversion,omitempty"`
+	MaxVersion   string         `xml:"maximumversion,omitempty"`
+}
+
+type LOMDuration struct {
+	Duration    string     `xml:"duration,omitempty"`
+	Description *LOMString `xml:"description,omitempty"`
+}
+
+type LOMEducational struct {
+	InteractivityType    *LOMVocabulary  `xml:"interactivitytype,omitempty"`
+	LearningResourceType []LOMVocabulary `xml:"learningresourcetype,omitempty"`
+	InteractivityLevel   *LOMVocabulary  `xml:"interactivitylevel,omitempty"`
+	SemanticDensity      *LOMVocabulary  `xml:"semanticdensity,omitempty"`
+	IntendedEndUserRole  []LOMVocabulary `xml:"intendedenduserrole,omitempty"`
+	Context              []LOMVocabulary `xml:"context,omitempty"`
+	TypicalAgeRange      []LOMString     `xml:"typicalagerange,omitempty"`
+	Difficulty           *LOMVocabulary  `xml:"difficulty,omitempty"`
+	TypicalLearningTime  *LOMDuration    `xml:"typicallearningtime,omitempty"`
+	Description          []LOMString     `xml:"description,omitempty"`
+	Language             []string        `xml:"language,omitempty"`
+}
+
+type LOMRights struct {
+	Cost                *LOMVocabulary `xml:"cost,omitempty"`
+	CopyrightAndOther   *LOMVocabulary `xml:"copyrightandotherrestrictions,omitempty"`
+	Description         *LOMString     `xml:"description,omitempty"`
+}
+
+// Common material structures used across versions
+
+type Material struct {
+	XMLName  xml.Name  `xml:"material"`
+	Label    string    `xml:"label,attr,omitempty"`
+	MatText  []MatText `xml:"mattext,omitempty"`
+	MatImage []MatImage `xml:"matimage,omitempty"`
+	MatAudio []MatAudio `xml:"mataudio,omitempty"`
+	MatVideo []MatVideo `xml:"matvideo,omitempty"`
+}
+
+type MatText struct {
+	XMLName     xml.Name `xml:"mattext"`
+	TextType    string   `xml:"texttype,attr,omitempty"`
+	Charset     string   `xml:"charset,attr,omitempty"`
+	XML         string   `xml:"xml:space,attr,omitempty"`
+	Content     string   `xml:",chardata"`
+}
+
+type MatImage struct {
+	XMLName    xml.Name `xml:"matimage"`
+	ImageType  string   `xml:"imagetype,attr,omitempty"`
+	URI        string   `xml:"uri,attr"`
+	Width      int      `xml:"width,attr,omitempty"`
+	Height     int      `xml:"height,attr,omitempty"`
+}
+
+type MatAudio struct {
+	XMLName    xml.Name `xml:"mataudio"`
+	AudioType  string   `xml:"audiotype,attr,omitempty"`
+	URI        string   `xml:"uri,attr"`
+}
+
+type MatVideo struct {
+	XMLName    xml.Name `xml:"matvideo"`
+	VideoType  string   `xml:"videotype,attr,omitempty"`
+	URI        string   `xml:"uri,attr"`
+	Width      int      `xml:"width,attr,omitempty"`
+	Height     int      `xml:"height,attr,omitempty"`
+}
+
+// Common structures that appear in multiple versions but might have slight variations
+
+type Objective struct {
+	XMLName  xml.Name  `xml:"objective"`
+	Title    string    `xml:"title,attr,omitempty"`
+	Material *Material `xml:"material,omitempty"`
+}
+
+type RubricBlock struct {
+	XMLName xml.Name  `xml:"rubricBlock"`
+	Use     string    `xml:"use,attr,omitempty"`
+	View    string    `xml:"view,attr,omitempty"`
+	Content string    `xml:",innerxml"`
+}

--- a/pkg/models/qti.go
+++ b/pkg/models/qti.go
@@ -2,9 +2,11 @@ package models
 
 import (
 	"encoding/xml"
-	"time"
 )
 
+// QTIDocument is a generic structure for backward compatibility
+// It's a union of all version-specific fields to support existing code
+// New code should use version-specific structures (QTIDocument12, QTIDocument21, QTIDocument30)
 type QTIDocument struct {
 	XMLName    xml.Name    `xml:"questestinterop"`
 	Version    string      `xml:"version,attr"`
@@ -31,14 +33,18 @@ type Section struct {
 	Metadata *Metadata `xml:"metadata,omitempty"`
 }
 
+// Item is a generic structure combining all version fields for backward compatibility
+// Use Item12, Item21, or Item30 for version-specific parsing
 type Item struct {
 	XMLName        xml.Name        `xml:"item"`
 	Title          string          `xml:"title,attr"`
 	Ident          string          `xml:"ident,attr"`
 	MaxAttempts    int             `xml:"maxattempts,attr,omitempty"`
 	Metadata       *Metadata       `xml:"metadata,omitempty"`
+	// QTI 1.2/2.1 fields
 	Presentation   *Presentation   `xml:"presentation,omitempty"`
 	ResponseProc   *ResponseProc   `xml:"resprocessing,omitempty"`
+	// QTI 2.1/3.0 fields
 	ItemBody       *ItemBody       `xml:"itemBody,omitempty"`
 	ResponseDecl   []ResponseDecl  `xml:"responseDeclaration,omitempty"`
 	OutcomeDecl    []OutcomeDecl   `xml:"outcomeDeclaration,omitempty"`
@@ -47,475 +53,30 @@ type Item struct {
 	RubricBlock    *RubricBlock    `xml:"rubricBlock,omitempty"`
 }
 
-type Metadata struct {
-	XMLName     xml.Name    `xml:"metadata"`
-	Schema      string      `xml:"schema,omitempty"`
-	SchemaVer   string      `xml:"schemaversion,omitempty"`
-	LOM         *LOM        `xml:"lom,omitempty"`
-	QTIMetadata *QTIMetadata `xml:"qtimetadata,omitempty"`
-}
+// Legacy types kept for backward compatibility
+// These are generic versions that combine fields from multiple QTI versions
+// For version-specific parsing, use the types in qti12.go, qti21.go, or qti30.go
 
-type LOM struct {
-	XMLName     xml.Name     `xml:"lom"`
-	General     *LOMGeneral  `xml:"general,omitempty"`
-	Lifecycle   *LOMLifecycle `xml:"lifecycle,omitempty"`
-	Technical   *LOMTechnical `xml:"technical,omitempty"`
-	Educational *LOMEducational `xml:"educational,omitempty"`
-	Rights      *LOMRights   `xml:"rights,omitempty"`
-}
+// Legacy types for backward compatibility
+// Note: Import these from version-specific files when needed
+// For now, we'll define minimal types here to avoid conflicts
 
-type LOMGeneral struct {
-	Identifier  []LOMIdentifier `xml:"identifier,omitempty"`
-	Title       *LOMString      `xml:"title,omitempty"`
-	Language    []string        `xml:"language,omitempty"`
-	Description []LOMString     `xml:"description,omitempty"`
-	Keyword     []LOMString     `xml:"keyword,omitempty"`
-}
-
-type LOMIdentifier struct {
-	Catalog string `xml:"catalog,omitempty"`
-	Entry   string `xml:"entry,omitempty"`
-}
-
-type LOMString struct {
-	Language string `xml:"language,attr,omitempty"`
-	Value    string `xml:",chardata"`
-}
-
-type LOMLifecycle struct {
-	Version     *LOMString      `xml:"version,omitempty"`
-	Status      *LOMVocabulary  `xml:"status,omitempty"`
-	Contribute  []LOMContribute `xml:"contribute,omitempty"`
-}
-
-type LOMVocabulary struct {
-	Source string `xml:"source,omitempty"`
-	Value  string `xml:"value,omitempty"`
-}
-
-type LOMContribute struct {
-	Role   *LOMVocabulary `xml:"role,omitempty"`
-	Entity []string       `xml:"entity,omitempty"`
-	Date   *LOMDateTime   `xml:"date,omitempty"`
-}
-
-type LOMDateTime struct {
-	DateTime    time.Time  `xml:"datetime,omitempty"`
-	Description *LOMString `xml:"description,omitempty"`
-}
-
-type LOMTechnical struct {
-	Format               []string              `xml:"format,omitempty"`
-	Size                 string                `xml:"size,omitempty"`
-	Location             []string              `xml:"location,omitempty"`
-	Requirement          []LOMRequirement      `xml:"requirement,omitempty"`
-	InstallationRemarks  *LOMString            `xml:"installationremarks,omitempty"`
-	OtherPlatformReq     *LOMString            `xml:"otherplatformrequirements,omitempty"`
-	Duration             *LOMDuration          `xml:"duration,omitempty"`
-}
-
-type LOMRequirement struct {
-	OrComposite []LOMOrComposite `xml:"orcomposite,omitempty"`
-}
-
-type LOMOrComposite struct {
-	Type         *LOMVocabulary `xml:"type,omitempty"`
-	Name         *LOMVocabulary `xml:"name,omitempty"`
-	MinVersion   string         `xml:"minimumversion,omitempty"`
-	MaxVersion   string         `xml:"maximumversion,omitempty"`
-}
-
-type LOMDuration struct {
-	Duration    string     `xml:"duration,omitempty"`
-	Description *LOMString `xml:"description,omitempty"`
-}
-
-type LOMEducational struct {
-	InteractivityType    *LOMVocabulary  `xml:"interactivitytype,omitempty"`
-	LearningResourceType []LOMVocabulary `xml:"learningresourcetype,omitempty"`
-	InteractivityLevel   *LOMVocabulary  `xml:"interactivitylevel,omitempty"`
-	SemanticDensity      *LOMVocabulary  `xml:"semanticdensity,omitempty"`
-	IntendedEndUserRole  []LOMVocabulary `xml:"intendedenduserrole,omitempty"`
-	Context              []LOMVocabulary `xml:"context,omitempty"`
-	TypicalAgeRange      []LOMString     `xml:"typicalagerange,omitempty"`
-	Difficulty           *LOMVocabulary  `xml:"difficulty,omitempty"`
-	TypicalLearningTime  *LOMDuration    `xml:"typicallearningtime,omitempty"`
-	Description          []LOMString     `xml:"description,omitempty"`
-	Language             []string        `xml:"language,omitempty"`
-}
-
-type LOMRights struct {
-	Cost                *LOMVocabulary `xml:"cost,omitempty"`
-	CopyrightAndOther   *LOMVocabulary `xml:"copyrightandotherrestrictions,omitempty"`
-	Description         *LOMString     `xml:"description,omitempty"`
-}
-
-type QTIMetadata struct {
-	XMLName            xml.Name    `xml:"qtimetadata"`
-	TimeDependent      bool        `xml:"timedependent,omitempty"`
-	Composite          bool        `xml:"composite,omitempty"`
-	InteractionType    string      `xml:"interactiontype,omitempty"`
-	FeedbackType       string      `xml:"feedbacktype,omitempty"`
-	SolutionAvailable  bool        `xml:"solutionavailable,omitempty"`
-	Scoringmode        string      `xml:"scoringmode,omitempty"`
-	ToolName           string      `xml:"toolname,omitempty"`
-	ToolVersion        string      `xml:"toolversion,omitempty"`
-	ToolVendor         string      `xml:"toolvendor,omitempty"`
-}
-
-type Presentation struct {
-	XMLName  xml.Name  `xml:"presentation"`
-	Label    string    `xml:"label,attr,omitempty"`
-	Material *Material `xml:"material,omitempty"`
-	Response []Response `xml:"response_lid,omitempty"`
-	Flow     []Flow     `xml:"flow,omitempty"`
-}
-
-type Material struct {
-	XMLName  xml.Name  `xml:"material"`
-	Label    string    `xml:"label,attr,omitempty"`
-	MatText  []MatText `xml:"mattext,omitempty"`
-	MatImage []MatImage `xml:"matimage,omitempty"`
-	MatAudio []MatAudio `xml:"mataudio,omitempty"`
-	MatVideo []MatVideo `xml:"matvideo,omitempty"`
-}
-
-type MatText struct {
-	XMLName     xml.Name `xml:"mattext"`
-	TextType    string   `xml:"texttype,attr,omitempty"`
-	Charset     string   `xml:"charset,attr,omitempty"`
-	XML         string   `xml:"xml:space,attr,omitempty"`
-	Content     string   `xml:",chardata"`
-}
-
-type MatImage struct {
-	XMLName    xml.Name `xml:"matimage"`
-	ImageType  string   `xml:"imagetype,attr,omitempty"`
-	URI        string   `xml:"uri,attr"`
-	Width      int      `xml:"width,attr,omitempty"`
-	Height     int      `xml:"height,attr,omitempty"`
-}
-
-type MatAudio struct {
-	XMLName    xml.Name `xml:"mataudio"`
-	AudioType  string   `xml:"audiotype,attr,omitempty"`
-	URI        string   `xml:"uri,attr"`
-}
-
-type MatVideo struct {
-	XMLName    xml.Name `xml:"matvideo"`
-	VideoType  string   `xml:"videotype,attr,omitempty"`
-	URI        string   `xml:"uri,attr"`
-	Width      int      `xml:"width,attr,omitempty"`
-	Height     int      `xml:"height,attr,omitempty"`
-}
-
-type Response struct {
-	XMLName      xml.Name      `xml:"response_lid"`
-	Ident        string        `xml:"ident,attr"`
-	RCardinality string        `xml:"rcardinality,attr,omitempty"`
-	RTiming      string        `xml:"rtiming,attr,omitempty"`
-	RenderChoice *RenderChoice `xml:"render_choice,omitempty"`
-	RenderFib    *RenderFib    `xml:"render_fib,omitempty"`
-}
-
-type RenderChoice struct {
-	XMLName    xml.Name    `xml:"render_choice"`
-	Shuffle    string      `xml:"shuffle,attr,omitempty"`
-	MInNumber  int         `xml:"minnumber,attr,omitempty"`
-	MaxNumber  int         `xml:"maxnumber,attr,omitempty"`
-	ResponseLabel []ResponseLabel `xml:"response_label"`
-}
-
-type ResponseLabel struct {
-	XMLName    xml.Name   `xml:"response_label"`
-	Ident      string     `xml:"ident,attr"`
-	RArea      string     `xml:"rarea,attr,omitempty"`
-	RRange     string     `xml:"rrange,attr,omitempty"`
-	Material   *Material  `xml:"material,omitempty"`
-}
-
-type RenderFib struct {
-	XMLName    xml.Name `xml:"render_fib"`
-	Encoding   string   `xml:"encoding,attr,omitempty"`
-	FibType    string   `xml:"fibtype,attr,omitempty"`
-	Rows       int      `xml:"rows,attr,omitempty"`
-	MaxChars   int      `xml:"maxchars,attr,omitempty"`
-	Prompt     string   `xml:"prompt,attr,omitempty"`
-	Columns    int      `xml:"columns,attr,omitempty"`
-}
-
-type Flow struct {
-	XMLName    xml.Name    `xml:"flow"`
-	Class      string      `xml:"class,attr,omitempty"`
-	Material   []Material  `xml:"material,omitempty"`
-	Response   []Response  `xml:"response_lid,omitempty"`
-	Flow       []Flow      `xml:"flow,omitempty"`
-}
-
-type ResponseProc struct {
-	XMLName    xml.Name    `xml:"resprocessing"`
-	ScoreModel string      `xml:"scoremodel,attr,omitempty"`
-	Outcomes   *Outcomes   `xml:"outcomes,omitempty"`
-	ResCondition []ResCondition `xml:"respcondition"`
-}
-
-type Outcomes struct {
-	XMLName     xml.Name     `xml:"outcomes"`
-	DecVar      []DecVar     `xml:"decvar"`
-}
-
-type DecVar struct {
-	XMLName     xml.Name `xml:"decvar"`
-	VarName     string   `xml:"varname,attr"`
-	VarType     string   `xml:"vartype,attr,omitempty"`
-	DefaultVal  string   `xml:"defaultval,attr,omitempty"`
-	MinValue    string   `xml:"minvalue,attr,omitempty"`
-	MaxValue    string   `xml:"maxvalue,attr,omitempty"`
-}
-
-type ResCondition struct {
-	XMLName     xml.Name     `xml:"respcondition"`
-	Title       string       `xml:"title,attr,omitempty"`
-	Continue    string       `xml:"continue,attr,omitempty"`
-	ConditionVar *ConditionVar `xml:"conditionvar"`
-	SetVar      []SetVar     `xml:"setvar,omitempty"`
-	DisplayFeedback []DisplayFeedback `xml:"displayfeedback,omitempty"`
-}
-
-type ConditionVar struct {
-	XMLName     xml.Name     `xml:"conditionvar"`
-	Not         *Not         `xml:"not,omitempty"`
-	And         *And         `xml:"and,omitempty"`
-	Or          *Or          `xml:"or,omitempty"`
-	VarEqual    []VarEqual   `xml:"varequal,omitempty"`
-	VarLT       []VarLT      `xml:"varlt,omitempty"`
-	VarLTE      []VarLTE     `xml:"varlte,omitempty"`
-	VarGT       []VarGT      `xml:"vargt,omitempty"`
-	VarGTE      []VarGTE     `xml:"vargte,omitempty"`
-	VarSubset   []VarSubset  `xml:"varsubset,omitempty"`
-	VarInside   []VarInside  `xml:"varinside,omitempty"`
-	VarSubstring []VarSubstring `xml:"varsubstring,omitempty"`
-}
-
-type Not struct {
-	XMLName     xml.Name     `xml:"not"`
-	VarEqual    []VarEqual   `xml:"varequal,omitempty"`
-	And         *And         `xml:"and,omitempty"`
-	Or          *Or          `xml:"or,omitempty"`
-}
-
-type And struct {
-	XMLName     xml.Name     `xml:"and"`
-	VarEqual    []VarEqual   `xml:"varequal,omitempty"`
-	Not         *Not         `xml:"not,omitempty"`
-	Or          *Or          `xml:"or,omitempty"`
-}
-
-type Or struct {
-	XMLName     xml.Name     `xml:"or"`
-	VarEqual    []VarEqual   `xml:"varequal,omitempty"`
-	Not         *Not         `xml:"not,omitempty"`
-	And         *And         `xml:"and,omitempty"`
-}
-
-type VarEqual struct {
-	XMLName     xml.Name `xml:"varequal"`
-	RespIdent   string   `xml:"respident,attr"`
-	Case        string   `xml:"case,attr,omitempty"`
-	Value       string   `xml:",chardata"`
-}
-
-type VarLT struct {
-	XMLName     xml.Name `xml:"varlt"`
-	RespIdent   string   `xml:"respident,attr"`
-	Value       string   `xml:",chardata"`
-}
-
-type VarLTE struct {
-	XMLName     xml.Name `xml:"varlte"`
-	RespIdent   string   `xml:"respident,attr"`
-	Value       string   `xml:",chardata"`
-}
-
-type VarGT struct {
-	XMLName     xml.Name `xml:"vargt"`
-	RespIdent   string   `xml:"respident,attr"`
-	Value       string   `xml:",chardata"`
-}
-
-type VarGTE struct {
-	XMLName     xml.Name `xml:"vargte"`
-	RespIdent   string   `xml:"respident,attr"`
-	Value       string   `xml:",chardata"`
-}
-
-type VarSubset struct {
-	XMLName     xml.Name `xml:"varsubset"`
-	RespIdent   string   `xml:"respident,attr"`
-	SetMatch    string   `xml:"setmatch,attr,omitempty"`
-	Value       string   `xml:",chardata"`
-}
-
-type VarInside struct {
-	XMLName     xml.Name `xml:"varinside"`
-	RespIdent   string   `xml:"respident,attr"`
-	AreaMatch   string   `xml:"areamatch,attr,omitempty"`
-	Value       string   `xml:",chardata"`
-}
-
-type VarSubstring struct {
-	XMLName     xml.Name `xml:"varsubstring"`
-	RespIdent   string   `xml:"respident,attr"`
-	Case        string   `xml:"case,attr,omitempty"`
-	Value       string   `xml:",chardata"`
-}
-
-type SetVar struct {
-	XMLName     xml.Name `xml:"setvar"`
-	Action      string   `xml:"action,attr"`
-	VarName     string   `xml:"varname,attr,omitempty"`
-	Value       string   `xml:",chardata"`
-}
-
-type DisplayFeedback struct {
-	XMLName     xml.Name `xml:"displayfeedback"`
-	FeedbackType string  `xml:"feedbacktype,attr,omitempty"`
-	LinkRefId   string   `xml:"linkrefid,attr"`
-}
-
-type ItemBody struct {
-	XMLName     xml.Name     `xml:"itemBody"`
-	P           []P          `xml:"p,omitempty"`
-	Div         []Div        `xml:"div,omitempty"`
-	ChoiceInteraction []ChoiceInteraction `xml:"choiceInteraction,omitempty"`
-	TextEntryInteraction []TextEntryInteraction `xml:"textEntryInteraction,omitempty"`
-	ExtendedTextInteraction []ExtendedTextInteraction `xml:"extendedTextInteraction,omitempty"`
-}
-
-type P struct {
-	XMLName xml.Name `xml:"p"`
-	Content string   `xml:",innerxml"`
-}
-
-type Div struct {
-	XMLName xml.Name `xml:"div"`
-	Class   string   `xml:"class,attr,omitempty"`
-	Content string   `xml:",innerxml"`
-}
-
-type ChoiceInteraction struct {
-	XMLName         xml.Name        `xml:"choiceInteraction"`
-	ResponseIdent   string          `xml:"responseIdentifier,attr"`
-	Shuffle         bool            `xml:"shuffle,attr,omitempty"`
-	MaxChoices      int             `xml:"maxChoices,attr,omitempty"`
-	MinChoices      int             `xml:"minChoices,attr,omitempty"`
-	Prompt          *Prompt         `xml:"prompt,omitempty"`
-	SimpleChoice    []SimpleChoice  `xml:"simpleChoice"`
-}
-
-type SimpleChoice struct {
-	XMLName     xml.Name `xml:"simpleChoice"`
-	Identifier  string   `xml:"identifier,attr"`
-	Fixed       bool     `xml:"fixed,attr,omitempty"`
-	Content     string   `xml:",innerxml"`
-}
-
-type Prompt struct {
-	XMLName xml.Name `xml:"prompt"`
-	Content string   `xml:",innerxml"`
-}
-
-type TextEntryInteraction struct {
-	XMLName         xml.Name `xml:"textEntryInteraction"`
-	ResponseIdent   string   `xml:"responseIdentifier,attr"`
-	ExpectedLength  int      `xml:"expectedLength,attr,omitempty"`
-	PatternMask     string   `xml:"patternMask,attr,omitempty"`
-	PlaceholderText string   `xml:"placeholderText,attr,omitempty"`
-}
-
-type ExtendedTextInteraction struct {
-	XMLName         xml.Name `xml:"extendedTextInteraction"`
-	ResponseIdent   string   `xml:"responseIdentifier,attr"`
-	MinStrings      int      `xml:"minStrings,attr,omitempty"`
-	MaxStrings      int      `xml:"maxStrings,attr,omitempty"`
-	ExpectedLines   int      `xml:"expectedLines,attr,omitempty"`
-	ExpectedLength  int      `xml:"expectedLength,attr,omitempty"`
-	Prompt          *Prompt  `xml:"prompt,omitempty"`
-}
-
-type ResponseDecl struct {
-	XMLName       xml.Name      `xml:"responseDeclaration"`
-	Identifier    string        `xml:"identifier,attr"`
-	Cardinality   string        `xml:"cardinality,attr"`
-	BaseType      string        `xml:"baseType,attr,omitempty"`
-	CorrectResponse *CorrectResponse `xml:"correctResponse,omitempty"`
-	Mapping       *Mapping      `xml:"mapping,omitempty"`
-}
-
-type CorrectResponse struct {
-	XMLName xml.Name `xml:"correctResponse"`
-	Value   []string `xml:"value"`
-}
-
-type Mapping struct {
-	XMLName        xml.Name    `xml:"mapping"`
-	LowerBound     float64     `xml:"lowerBound,attr,omitempty"`
-	UpperBound     float64     `xml:"upperBound,attr,omitempty"`
-	DefaultValue   float64     `xml:"defaultValue,attr,omitempty"`
-	MapEntry       []MapEntry  `xml:"mapEntry"`
-}
-
-type MapEntry struct {
-	XMLName    xml.Name `xml:"mapEntry"`
-	MapKey     string   `xml:"mapKey,attr"`
-	MappedValue float64 `xml:"mappedValue,attr"`
-}
-
-type OutcomeDecl struct {
-	XMLName         xml.Name        `xml:"outcomeDeclaration"`
-	Identifier      string          `xml:"identifier,attr"`
-	Cardinality     string          `xml:"cardinality,attr"`
-	BaseType        string          `xml:"baseType,attr,omitempty"`
-	DefaultValue    *DefaultValue   `xml:"defaultValue,omitempty"`
-}
-
-type DefaultValue struct {
-	XMLName xml.Name `xml:"defaultValue"`
-	Value   string   `xml:"value"`
-}
-
-type TemplateDecl struct {
-	XMLName      xml.Name     `xml:"templateDeclaration"`
-	Identifier   string       `xml:"identifier,attr"`
-	Cardinality  string       `xml:"cardinality,attr"`
-	BaseType     string       `xml:"baseType,attr,omitempty"`
-	ParamVariable bool        `xml:"paramVariable,attr,omitempty"`
-	DefaultValue *DefaultValue `xml:"defaultValue,omitempty"`
-}
-
-type Feedback struct {
-	XMLName        xml.Name       `xml:"itemfeedback"`
-	Ident          string         `xml:"ident,attr"`
-	Title          string         `xml:"title,attr,omitempty"`
-	FlowMat        []FlowMat      `xml:"flow_mat,omitempty"`
-	Material       *Material      `xml:"material,omitempty"`
-}
-
-type FlowMat struct {
-	XMLName  xml.Name  `xml:"flow_mat"`
-	Material *Material `xml:"material,omitempty"`
-}
-
-type Objective struct {
-	XMLName  xml.Name  `xml:"objective"`
-	Title    string    `xml:"title,attr,omitempty"`
-	Material *Material `xml:"material,omitempty"`
-}
-
-type RubricBlock struct {
-	XMLName xml.Name  `xml:"rubricBlock"`
-	Use     string    `xml:"use,attr,omitempty"`
-	View    string    `xml:"view,attr,omitempty"`
-	Content string    `xml:",innerxml"`
-}
+// Generic types that combine fields from multiple versions
+type Response = Response12
+type Flow = Flow12
+type ItemBody = ItemBody21
+type P = P21
+type Div = Div21
+type ChoiceInteraction = ChoiceInteraction21
+type SimpleChoice = SimpleChoice21
+type Prompt = Prompt21
+type TextEntryInteraction = TextEntryInteraction21
+type ExtendedTextInteraction = ExtendedTextInteraction21
+type ResponseDecl = ResponseDecl21
+type CorrectResponse = CorrectResponse21
+type Mapping = Mapping21
+type MapEntry = MapEntry21
+type OutcomeDecl = OutcomeDecl21
+type DefaultValue = DefaultValue21
+type TemplateDecl = TemplateDecl21
+type Feedback = Feedback21

--- a/pkg/models/qti12.go
+++ b/pkg/models/qti12.go
@@ -1,0 +1,244 @@
+package models
+
+import "encoding/xml"
+
+// QTI 1.2 specific structures
+
+type QTIDocument12 struct {
+	XMLName    xml.Name    `xml:"questestinterop"`
+	Version    string      `xml:"version,attr"`
+	Items      []Item12    `xml:"item"`
+	Assessment *Assessment12 `xml:"assessment,omitempty"`
+	Metadata   *Metadata   `xml:"metadata,omitempty"`
+}
+
+type Assessment12 struct {
+	XMLName     xml.Name     `xml:"assessment"`
+	Title       string       `xml:"title,attr"`
+	Ident       string       `xml:"ident,attr"`
+	Sections    []Section12  `xml:"section"`
+	Metadata    *Metadata    `xml:"metadata,omitempty"`
+	Objectives  []Objective  `xml:"objectives>objective,omitempty"`
+	RubricBlock *RubricBlock `xml:"rubricBlock,omitempty"`
+}
+
+type Section12 struct {
+	XMLName  xml.Name  `xml:"section"`
+	Title    string    `xml:"title,attr"`
+	Ident    string    `xml:"ident,attr"`
+	Items    []Item12  `xml:"item"`
+	Metadata *Metadata `xml:"metadata,omitempty"`
+}
+
+type Item12 struct {
+	XMLName        xml.Name        `xml:"item"`
+	Title          string          `xml:"title,attr"`
+	Ident          string          `xml:"ident,attr"`
+	MaxAttempts    int             `xml:"maxattempts,attr,omitempty"`
+	Metadata       *Metadata       `xml:"metadata,omitempty"`
+	Presentation   *Presentation   `xml:"presentation,omitempty"`
+	ResponseProc   *ResponseProc   `xml:"resprocessing,omitempty"`
+	Feedback       []Feedback12    `xml:"itemfeedback,omitempty"`
+	RubricBlock    *RubricBlock    `xml:"rubricBlock,omitempty"`
+}
+
+// QTI 1.2 Presentation structures
+
+type Presentation struct {
+	XMLName  xml.Name  `xml:"presentation"`
+	Label    string    `xml:"label,attr,omitempty"`
+	Material *Material `xml:"material,omitempty"`
+	Response []Response12 `xml:"response_lid,omitempty"`
+	Flow     []Flow12     `xml:"flow,omitempty"`
+}
+
+type Response12 struct {
+	XMLName      xml.Name      `xml:"response_lid"`
+	Ident        string        `xml:"ident,attr"`
+	RCardinality string        `xml:"rcardinality,attr,omitempty"`
+	RTiming      string        `xml:"rtiming,attr,omitempty"`
+	RenderChoice *RenderChoice `xml:"render_choice,omitempty"`
+	RenderFib    *RenderFib    `xml:"render_fib,omitempty"`
+}
+
+type RenderChoice struct {
+	XMLName    xml.Name    `xml:"render_choice"`
+	Shuffle    string      `xml:"shuffle,attr,omitempty"`
+	MInNumber  int         `xml:"minnumber,attr,omitempty"`
+	MaxNumber  int         `xml:"maxnumber,attr,omitempty"`
+	ResponseLabel []ResponseLabel `xml:"response_label"`
+}
+
+type ResponseLabel struct {
+	XMLName    xml.Name   `xml:"response_label"`
+	Ident      string     `xml:"ident,attr"`
+	RArea      string     `xml:"rarea,attr,omitempty"`
+	RRange     string     `xml:"rrange,attr,omitempty"`
+	Material   *Material  `xml:"material,omitempty"`
+}
+
+type RenderFib struct {
+	XMLName    xml.Name `xml:"render_fib"`
+	Encoding   string   `xml:"encoding,attr,omitempty"`
+	FibType    string   `xml:"fibtype,attr,omitempty"`
+	Rows       int      `xml:"rows,attr,omitempty"`
+	MaxChars   int      `xml:"maxchars,attr,omitempty"`
+	Prompt     string   `xml:"prompt,attr,omitempty"`
+	Columns    int      `xml:"columns,attr,omitempty"`
+}
+
+type Flow12 struct {
+	XMLName    xml.Name    `xml:"flow"`
+	Class      string      `xml:"class,attr,omitempty"`
+	Material   []Material  `xml:"material,omitempty"`
+	Response   []Response12 `xml:"response_lid,omitempty"`
+	Flow       []Flow12     `xml:"flow,omitempty"`
+}
+
+// QTI 1.2 Response Processing structures
+
+type ResponseProc struct {
+	XMLName    xml.Name    `xml:"resprocessing"`
+	ScoreModel string      `xml:"scoremodel,attr,omitempty"`
+	Outcomes   *Outcomes   `xml:"outcomes,omitempty"`
+	ResCondition []ResCondition `xml:"respcondition"`
+}
+
+type Outcomes struct {
+	XMLName     xml.Name     `xml:"outcomes"`
+	DecVar      []DecVar     `xml:"decvar"`
+}
+
+type DecVar struct {
+	XMLName     xml.Name `xml:"decvar"`
+	VarName     string   `xml:"varname,attr"`
+	VarType     string   `xml:"vartype,attr,omitempty"`
+	DefaultVal  string   `xml:"defaultval,attr,omitempty"`
+	MinValue    string   `xml:"minvalue,attr,omitempty"`
+	MaxValue    string   `xml:"maxvalue,attr,omitempty"`
+}
+
+type ResCondition struct {
+	XMLName     xml.Name     `xml:"respcondition"`
+	Title       string       `xml:"title,attr,omitempty"`
+	Continue    string       `xml:"continue,attr,omitempty"`
+	ConditionVar *ConditionVar `xml:"conditionvar"`
+	SetVar      []SetVar     `xml:"setvar,omitempty"`
+	DisplayFeedback []DisplayFeedback `xml:"displayfeedback,omitempty"`
+}
+
+type ConditionVar struct {
+	XMLName     xml.Name     `xml:"conditionvar"`
+	Not         *Not         `xml:"not,omitempty"`
+	And         *And         `xml:"and,omitempty"`
+	Or          *Or          `xml:"or,omitempty"`
+	VarEqual    []VarEqual   `xml:"varequal,omitempty"`
+	VarLT       []VarLT      `xml:"varlt,omitempty"`
+	VarLTE      []VarLTE     `xml:"varlte,omitempty"`
+	VarGT       []VarGT      `xml:"vargt,omitempty"`
+	VarGTE      []VarGTE     `xml:"vargte,omitempty"`
+	VarSubset   []VarSubset  `xml:"varsubset,omitempty"`
+	VarInside   []VarInside  `xml:"varinside,omitempty"`
+	VarSubstring []VarSubstring `xml:"varsubstring,omitempty"`
+}
+
+type Not struct {
+	XMLName     xml.Name     `xml:"not"`
+	VarEqual    []VarEqual   `xml:"varequal,omitempty"`
+	And         *And         `xml:"and,omitempty"`
+	Or          *Or          `xml:"or,omitempty"`
+}
+
+type And struct {
+	XMLName     xml.Name     `xml:"and"`
+	VarEqual    []VarEqual   `xml:"varequal,omitempty"`
+	Not         *Not         `xml:"not,omitempty"`
+	Or          *Or          `xml:"or,omitempty"`
+}
+
+type Or struct {
+	XMLName     xml.Name     `xml:"or"`
+	VarEqual    []VarEqual   `xml:"varequal,omitempty"`
+	Not         *Not         `xml:"not,omitempty"`
+	And         *And         `xml:"and,omitempty"`
+}
+
+type VarEqual struct {
+	XMLName     xml.Name `xml:"varequal"`
+	RespIdent   string   `xml:"respident,attr"`
+	Case        string   `xml:"case,attr,omitempty"`
+	Value       string   `xml:",chardata"`
+}
+
+type VarLT struct {
+	XMLName     xml.Name `xml:"varlt"`
+	RespIdent   string   `xml:"respident,attr"`
+	Value       string   `xml:",chardata"`
+}
+
+type VarLTE struct {
+	XMLName     xml.Name `xml:"varlte"`
+	RespIdent   string   `xml:"respident,attr"`
+	Value       string   `xml:",chardata"`
+}
+
+type VarGT struct {
+	XMLName     xml.Name `xml:"vargt"`
+	RespIdent   string   `xml:"respident,attr"`
+	Value       string   `xml:",chardata"`
+}
+
+type VarGTE struct {
+	XMLName     xml.Name `xml:"vargte"`
+	RespIdent   string   `xml:"respident,attr"`
+	Value       string   `xml:",chardata"`
+}
+
+type VarSubset struct {
+	XMLName     xml.Name `xml:"varsubset"`
+	RespIdent   string   `xml:"respident,attr"`
+	SetMatch    string   `xml:"setmatch,attr,omitempty"`
+	Value       string   `xml:",chardata"`
+}
+
+type VarInside struct {
+	XMLName     xml.Name `xml:"varinside"`
+	RespIdent   string   `xml:"respident,attr"`
+	AreaMatch   string   `xml:"areamatch,attr,omitempty"`
+	Value       string   `xml:",chardata"`
+}
+
+type VarSubstring struct {
+	XMLName     xml.Name `xml:"varsubstring"`
+	RespIdent   string   `xml:"respident,attr"`
+	Case        string   `xml:"case,attr,omitempty"`
+	Value       string   `xml:",chardata"`
+}
+
+type SetVar struct {
+	XMLName     xml.Name `xml:"setvar"`
+	Action      string   `xml:"action,attr"`
+	VarName     string   `xml:"varname,attr,omitempty"`
+	Value       string   `xml:",chardata"`
+}
+
+type DisplayFeedback struct {
+	XMLName     xml.Name `xml:"displayfeedback"`
+	FeedbackType string  `xml:"feedbacktype,attr,omitempty"`
+	LinkRefId   string   `xml:"linkrefid,attr"`
+}
+
+// QTI 1.2 Feedback structures
+
+type Feedback12 struct {
+	XMLName        xml.Name       `xml:"itemfeedback"`
+	Ident          string         `xml:"ident,attr"`
+	Title          string         `xml:"title,attr,omitempty"`
+	FlowMat        []FlowMat      `xml:"flow_mat,omitempty"`
+	Material       *Material      `xml:"material,omitempty"`
+}
+
+type FlowMat struct {
+	XMLName  xml.Name  `xml:"flow_mat"`
+	Material *Material `xml:"material,omitempty"`
+}

--- a/pkg/models/qti21.go
+++ b/pkg/models/qti21.go
@@ -1,0 +1,176 @@
+package models
+
+import "encoding/xml"
+
+// QTI 2.1/2.2 specific structures
+// Note: QTI 2.1 and 2.2 share the same structure with minor differences in behavior
+
+type QTIDocument21 struct {
+	XMLName    xml.Name    `xml:"questestinterop"`
+	Version    string      `xml:"version,attr"`
+	Items      []Item21    `xml:"item"`
+	Assessment *Assessment21 `xml:"assessment,omitempty"`
+	Metadata   *Metadata   `xml:"metadata,omitempty"`
+}
+
+type Assessment21 struct {
+	XMLName     xml.Name     `xml:"assessment"`
+	Title       string       `xml:"title,attr"`
+	Ident       string       `xml:"ident,attr"`
+	Sections    []Section21  `xml:"section"`
+	Metadata    *Metadata    `xml:"metadata,omitempty"`
+	Objectives  []Objective  `xml:"objectives>objective,omitempty"`
+	RubricBlock *RubricBlock `xml:"rubricBlock,omitempty"`
+}
+
+type Section21 struct {
+	XMLName  xml.Name  `xml:"section"`
+	Title    string    `xml:"title,attr"`
+	Ident    string    `xml:"ident,attr"`
+	Items    []Item21  `xml:"item"`
+	Metadata *Metadata `xml:"metadata,omitempty"`
+}
+
+// QTI 2.1/2.2 uses a hybrid structure that supports both 1.2 legacy and newer elements
+type Item21 struct {
+	XMLName        xml.Name        `xml:"item"`
+	Title          string          `xml:"title,attr"`
+	Ident          string          `xml:"ident,attr"`
+	MaxAttempts    int             `xml:"maxattempts,attr,omitempty"`
+	Metadata       *Metadata       `xml:"metadata,omitempty"`
+	// Legacy 1.2 structures still supported
+	Presentation   *Presentation   `xml:"presentation,omitempty"`
+	ResponseProc   *ResponseProc   `xml:"resprocessing,omitempty"`
+	// Newer 2.x structures
+	ItemBody       *ItemBody21     `xml:"itemBody,omitempty"`
+	ResponseDecl   []ResponseDecl21  `xml:"responseDeclaration,omitempty"`
+	OutcomeDecl    []OutcomeDecl21   `xml:"outcomeDeclaration,omitempty"`
+	TemplateDecl   []TemplateDecl21  `xml:"templateDeclaration,omitempty"`
+	Feedback       []Feedback21    `xml:"itemfeedback,omitempty"`
+	RubricBlock    *RubricBlock    `xml:"rubricBlock,omitempty"`
+}
+
+// QTI 2.1/2.2 ItemBody structures
+
+type ItemBody21 struct {
+	XMLName     xml.Name     `xml:"itemBody"`
+	P           []P21        `xml:"p,omitempty"`
+	Div         []Div21      `xml:"div,omitempty"`
+	ChoiceInteraction []ChoiceInteraction21 `xml:"choiceInteraction,omitempty"`
+	TextEntryInteraction []TextEntryInteraction21 `xml:"textEntryInteraction,omitempty"`
+	ExtendedTextInteraction []ExtendedTextInteraction21 `xml:"extendedTextInteraction,omitempty"`
+}
+
+type P21 struct {
+	XMLName xml.Name `xml:"p"`
+	Content string   `xml:",innerxml"`
+}
+
+type Div21 struct {
+	XMLName xml.Name `xml:"div"`
+	Class   string   `xml:"class,attr,omitempty"`
+	Content string   `xml:",innerxml"`
+}
+
+type ChoiceInteraction21 struct {
+	XMLName         xml.Name        `xml:"choiceInteraction"`
+	ResponseIdent   string          `xml:"responseIdentifier,attr"`
+	Shuffle         bool            `xml:"shuffle,attr,omitempty"`
+	MaxChoices      int             `xml:"maxChoices,attr,omitempty"`
+	MinChoices      int             `xml:"minChoices,attr,omitempty"`
+	Prompt          *Prompt21       `xml:"prompt,omitempty"`
+	SimpleChoice    []SimpleChoice21 `xml:"simpleChoice"`
+}
+
+type SimpleChoice21 struct {
+	XMLName     xml.Name `xml:"simpleChoice"`
+	Identifier  string   `xml:"identifier,attr"`
+	Fixed       bool     `xml:"fixed,attr,omitempty"`
+	Content     string   `xml:",innerxml"`
+}
+
+type Prompt21 struct {
+	XMLName xml.Name `xml:"prompt"`
+	Content string   `xml:",innerxml"`
+}
+
+type TextEntryInteraction21 struct {
+	XMLName         xml.Name `xml:"textEntryInteraction"`
+	ResponseIdent   string   `xml:"responseIdentifier,attr"`
+	ExpectedLength  int      `xml:"expectedLength,attr,omitempty"`
+	PatternMask     string   `xml:"patternMask,attr,omitempty"`
+	PlaceholderText string   `xml:"placeholderText,attr,omitempty"`
+}
+
+type ExtendedTextInteraction21 struct {
+	XMLName         xml.Name `xml:"extendedTextInteraction"`
+	ResponseIdent   string   `xml:"responseIdentifier,attr"`
+	MinStrings      int      `xml:"minStrings,attr,omitempty"`
+	MaxStrings      int      `xml:"maxStrings,attr,omitempty"`
+	ExpectedLines   int      `xml:"expectedLines,attr,omitempty"`
+	ExpectedLength  int      `xml:"expectedLength,attr,omitempty"`
+	Prompt          *Prompt21 `xml:"prompt,omitempty"`
+}
+
+// QTI 2.1/2.2 Declaration structures
+
+type ResponseDecl21 struct {
+	XMLName       xml.Name      `xml:"responseDeclaration"`
+	Identifier    string        `xml:"identifier,attr"`
+	Cardinality   string        `xml:"cardinality,attr"`
+	BaseType      string        `xml:"baseType,attr,omitempty"`
+	CorrectResponse *CorrectResponse21 `xml:"correctResponse,omitempty"`
+	Mapping       *Mapping21    `xml:"mapping,omitempty"`
+}
+
+type CorrectResponse21 struct {
+	XMLName xml.Name `xml:"correctResponse"`
+	Value   []string `xml:"value"`
+}
+
+type Mapping21 struct {
+	XMLName        xml.Name    `xml:"mapping"`
+	LowerBound     float64     `xml:"lowerBound,attr,omitempty"`
+	UpperBound     float64     `xml:"upperBound,attr,omitempty"`
+	DefaultValue   float64     `xml:"defaultValue,attr,omitempty"`
+	MapEntry       []MapEntry21 `xml:"mapEntry"`
+}
+
+type MapEntry21 struct {
+	XMLName    xml.Name `xml:"mapEntry"`
+	MapKey     string   `xml:"mapKey,attr"`
+	MappedValue float64 `xml:"mappedValue,attr"`
+}
+
+type OutcomeDecl21 struct {
+	XMLName         xml.Name        `xml:"outcomeDeclaration"`
+	Identifier      string          `xml:"identifier,attr"`
+	Cardinality     string          `xml:"cardinality,attr"`
+	BaseType        string          `xml:"baseType,attr,omitempty"`
+	DefaultValue    *DefaultValue21 `xml:"defaultValue,omitempty"`
+}
+
+type DefaultValue21 struct {
+	XMLName xml.Name `xml:"defaultValue"`
+	Value   string   `xml:"value"`
+}
+
+type TemplateDecl21 struct {
+	XMLName      xml.Name     `xml:"templateDeclaration"`
+	Identifier   string       `xml:"identifier,attr"`
+	Cardinality  string       `xml:"cardinality,attr"`
+	BaseType     string       `xml:"baseType,attr,omitempty"`
+	ParamVariable bool        `xml:"paramVariable,attr,omitempty"`
+	DefaultValue *DefaultValue21 `xml:"defaultValue,omitempty"`
+}
+
+// QTI 2.1/2.2 Feedback structures
+// Note: Can use both legacy format and newer format
+
+type Feedback21 struct {
+	XMLName        xml.Name       `xml:"itemfeedback"`
+	Ident          string         `xml:"ident,attr"`
+	Title          string         `xml:"title,attr,omitempty"`
+	FlowMat        []FlowMat      `xml:"flow_mat,omitempty"` // Legacy 1.2 style
+	Material       *Material      `xml:"material,omitempty"`  // Can be used directly
+}

--- a/pkg/models/qti30.go
+++ b/pkg/models/qti30.go
@@ -1,0 +1,219 @@
+package models
+
+import "encoding/xml"
+
+// QTI 3.0 specific structures
+// QTI 3.0 represents a major overhaul with cleaner, more modern XML structure
+
+type QTIDocument30 struct {
+	XMLName    xml.Name      `xml:"qtiAssessmentItem"`
+	Version    string        `xml:"version,attr"`
+	Identifier string        `xml:"identifier,attr"`
+	Title      string        `xml:"title,attr"`
+	TimeDependent bool       `xml:"timeDependent,attr,omitempty"`
+	Adaptive   bool          `xml:"adaptive,attr,omitempty"`
+	// Declarations come first in QTI 3.0
+	ResponseDeclarations []ResponseDecl30 `xml:"responseDeclaration,omitempty"`
+	OutcomeDeclarations  []OutcomeDecl30  `xml:"outcomeDeclaration,omitempty"`
+	TemplateDeclarations []TemplateDecl30 `xml:"templateDeclaration,omitempty"`
+	// Content
+	ItemBody       *ItemBody30      `xml:"itemBody"`
+	ResponseProcessing *ResponseProcessing30 `xml:"responseProcessing,omitempty"`
+	ModalFeedback  []ModalFeedback30 `xml:"modalFeedback,omitempty"`
+	// Metadata
+	Metadata       *Metadata        `xml:"metadata,omitempty"`
+}
+
+// QTI 3.0 uses a different root for assessments
+type Assessment30 struct {
+	XMLName    xml.Name      `xml:"assessmentTest"`
+	Identifier string        `xml:"identifier,attr"`
+	Title      string        `xml:"title,attr"`
+	TestParts  []TestPart30  `xml:"testPart"`
+	Metadata   *Metadata     `xml:"metadata,omitempty"`
+}
+
+type TestPart30 struct {
+	XMLName        xml.Name          `xml:"testPart"`
+	Identifier     string            `xml:"identifier,attr"`
+	NavigationMode string            `xml:"navigationMode,attr,omitempty"`
+	SubmissionMode string            `xml:"submissionMode,attr,omitempty"`
+	Sections       []AssessmentSection30 `xml:"assessmentSection"`
+}
+
+type AssessmentSection30 struct {
+	XMLName    xml.Name   `xml:"assessmentSection"`
+	Identifier string     `xml:"identifier,attr"`
+	Title      string     `xml:"title,attr"`
+	Visible    bool       `xml:"visible,attr,omitempty"`
+	ItemRefs   []ItemRef30 `xml:"assessmentItemRef"`
+	Metadata   *Metadata  `xml:"metadata,omitempty"`
+}
+
+type ItemRef30 struct {
+	XMLName    xml.Name `xml:"assessmentItemRef"`
+	Identifier string   `xml:"identifier,attr"`
+	Href       string   `xml:"href,attr"`
+	Category   []string `xml:"category,attr,omitempty"`
+}
+
+// QTI 3.0 ItemBody - cleaner structure than 2.x
+
+type ItemBody30 struct {
+	XMLName xml.Name `xml:"itemBody"`
+	// Content can include various interactions and block elements
+	Content []interface{} `xml:",any"`
+}
+
+// QTI 3.0 Interactions - more structured than previous versions
+
+type ChoiceInteraction30 struct {
+	XMLName               xml.Name        `xml:"choiceInteraction"`
+	ResponseIdentifier    string          `xml:"responseIdentifier,attr"`
+	Shuffle               bool            `xml:"shuffle,attr,omitempty"`
+	MaxChoices            int             `xml:"maxChoices,attr,omitempty"`
+	MinChoices            int             `xml:"minChoices,attr,omitempty"`
+	Orientation           string          `xml:"orientation,attr,omitempty"`
+	Prompt                *Prompt30       `xml:"prompt,omitempty"`
+	SimpleChoice          []SimpleChoice30 `xml:"simpleChoice"`
+}
+
+type SimpleChoice30 struct {
+	XMLName     xml.Name `xml:"simpleChoice"`
+	Identifier  string   `xml:"identifier,attr"`
+	Fixed       bool     `xml:"fixed,attr,omitempty"`
+	ShowHide    string   `xml:"showHide,attr,omitempty"`
+	Content     string   `xml:",innerxml"`
+}
+
+type TextEntryInteraction30 struct {
+	XMLName            xml.Name `xml:"textEntryInteraction"`
+	ResponseIdentifier string   `xml:"responseIdentifier,attr"`
+	Base               int      `xml:"base,attr,omitempty"`
+	StringIdentifier   string   `xml:"stringIdentifier,attr,omitempty"`
+	ExpectedLength     int      `xml:"expectedLength,attr,omitempty"`
+	PatternMask        string   `xml:"patternMask,attr,omitempty"`
+	PlaceholderText    string   `xml:"placeholderText,attr,omitempty"`
+}
+
+type ExtendedTextInteraction30 struct {
+	XMLName            xml.Name  `xml:"extendedTextInteraction"`
+	ResponseIdentifier string    `xml:"responseIdentifier,attr"`
+	Base               int       `xml:"base,attr,omitempty"`
+	StringIdentifier   string    `xml:"stringIdentifier,attr,omitempty"`
+	ExpectedLength     int       `xml:"expectedLength,attr,omitempty"`
+	PatternMask        string    `xml:"patternMask,attr,omitempty"`
+	PlaceholderText    string    `xml:"placeholderText,attr,omitempty"`
+	MaxStrings         int       `xml:"maxStrings,attr,omitempty"`
+	MinStrings         int       `xml:"minStrings,attr,omitempty"`
+	ExpectedLines      int       `xml:"expectedLines,attr,omitempty"`
+	Format             string    `xml:"format,attr,omitempty"`
+	Prompt             *Prompt30 `xml:"prompt,omitempty"`
+}
+
+type Prompt30 struct {
+	XMLName xml.Name `xml:"prompt"`
+	Content string   `xml:",innerxml"`
+}
+
+// QTI 3.0 Declarations - more structured than 2.x
+
+type ResponseDecl30 struct {
+	XMLName         xml.Name           `xml:"responseDeclaration"`
+	Identifier      string             `xml:"identifier,attr"`
+	Cardinality     string             `xml:"cardinality,attr"`
+	BaseType        string             `xml:"baseType,attr,omitempty"`
+	CorrectResponse *CorrectResponse30 `xml:"correctResponse,omitempty"`
+	Mapping         *Mapping30         `xml:"mapping,omitempty"`
+	AreaMapping     *AreaMapping30     `xml:"areaMapping,omitempty"`
+}
+
+type CorrectResponse30 struct {
+	XMLName xml.Name  `xml:"correctResponse"`
+	Value   []Value30 `xml:"value"`
+}
+
+type Value30 struct {
+	XMLName    xml.Name `xml:"value"`
+	FieldIdentifier string `xml:"fieldIdentifier,attr,omitempty"`
+	BaseType   string   `xml:"baseType,attr,omitempty"`
+	Content    string   `xml:",chardata"`
+}
+
+type Mapping30 struct {
+	XMLName      xml.Name      `xml:"mapping"`
+	LowerBound   float64       `xml:"lowerBound,attr,omitempty"`
+	UpperBound   float64       `xml:"upperBound,attr,omitempty"`
+	DefaultValue float64       `xml:"defaultValue,attr"`
+	MapEntry     []MapEntry30  `xml:"mapEntry"`
+}
+
+type MapEntry30 struct {
+	XMLName     xml.Name `xml:"mapEntry"`
+	MapKey      string   `xml:"mapKey,attr"`
+	MappedValue float64  `xml:"mappedValue,attr"`
+}
+
+type AreaMapping30 struct {
+	XMLName          xml.Name         `xml:"areaMapping"`
+	LowerBound       float64          `xml:"lowerBound,attr,omitempty"`
+	UpperBound       float64          `xml:"upperBound,attr,omitempty"`
+	DefaultValue     float64          `xml:"defaultValue,attr"`
+	AreaMapEntry     []AreaMapEntry30 `xml:"areaMapEntry"`
+}
+
+type AreaMapEntry30 struct {
+	XMLName     xml.Name `xml:"areaMapEntry"`
+	Shape       string   `xml:"shape,attr"`
+	Coords      string   `xml:"coords,attr"`
+	MappedValue float64  `xml:"mappedValue,attr"`
+}
+
+type OutcomeDecl30 struct {
+	XMLName         xml.Name         `xml:"outcomeDeclaration"`
+	Identifier      string           `xml:"identifier,attr"`
+	Cardinality     string           `xml:"cardinality,attr"`
+	BaseType        string           `xml:"baseType,attr,omitempty"`
+	View            []string         `xml:"view,attr,omitempty"`
+	Interpretation  string           `xml:"interpretation,attr,omitempty"`
+	LongInterpretation string        `xml:"longInterpretation,attr,omitempty"`
+	NormalMaximum   float64          `xml:"normalMaximum,attr,omitempty"`
+	NormalMinimum   float64          `xml:"normalMinimum,attr,omitempty"`
+	MasteryValue    float64          `xml:"masteryValue,attr,omitempty"`
+	DefaultValue    *DefaultValue30  `xml:"defaultValue,omitempty"`
+}
+
+type DefaultValue30 struct {
+	XMLName xml.Name  `xml:"defaultValue"`
+	Value   []Value30 `xml:"value"`
+}
+
+type TemplateDecl30 struct {
+	XMLName       xml.Name        `xml:"templateDeclaration"`
+	Identifier    string          `xml:"identifier,attr"`
+	Cardinality   string          `xml:"cardinality,attr"`
+	BaseType      string          `xml:"baseType,attr,omitempty"`
+	ParamVariable bool            `xml:"paramVariable,attr,omitempty"`
+	MathVariable  bool            `xml:"mathVariable,attr,omitempty"`
+	DefaultValue  *DefaultValue30 `xml:"defaultValue,omitempty"`
+}
+
+// QTI 3.0 Response Processing - completely different from resprocessing
+
+type ResponseProcessing30 struct {
+	XMLName             xml.Name              `xml:"responseProcessing"`
+	Template            string                `xml:"template,attr,omitempty"`
+	TemplateLocation    string                `xml:"templateLocation,attr,omitempty"`
+	ResponseRules       []interface{}         `xml:",any"` // Can contain various rule types
+}
+
+// QTI 3.0 Modal Feedback
+
+type ModalFeedback30 struct {
+	XMLName    xml.Name `xml:"modalFeedback"`
+	Identifier string   `xml:"identifier,attr"`
+	OutcomeIdentifier string `xml:"outcomeIdentifier,attr"`
+	ShowHide   string   `xml:"showHide,attr"`
+	Title      string   `xml:"title,attr,omitempty"`
+	Content    string   `xml:",innerxml"`
+}


### PR DESCRIPTION
This refactoring separates QTI parsing logic by version to improve maintainability and code clarity.

## Changes:

### New Files:
- `pkg/models/common.go` - Shared structures (LOM metadata, materials)
- `pkg/models/qti12.go` - QTI 1.2 specific structures
- `pkg/models/qti21.go` - QTI 2.1/2.2 specific structures
- `pkg/models/qti30.go` - QTI 3.0 specific structures
- `internal/parser/qti30/parser.go` - Dedicated QTI 3.0 parser

### Updated Files:
- `pkg/models/qti.go` - Now provides type aliases for backward compatibility
- `internal/parser/qti12/parser.go` - Uses QTI 1.2 models with converters
- `internal/parser/qti21/parser.go` - Uses QTI 2.1 models with converters
- `internal/parser/factory.go` - Updated to use QTI 3.0 parser
- `internal/parser/factory_test.go` - Updated test expectations
- `README.md` - Added architecture documentation

## Benefits:
- Clear separation of concerns between QTI versions
- Easier to understand version-specific parsing logic
- Better maintainability for future changes
- Backward compatibility maintained through type aliases
- All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated support for QTI 3.0, including a new parser and comprehensive data models.
  * Enhanced separation of QTI 1.2, 2.1/2.2, and 3.0 version structures for improved maintainability and clarity.
  * Introduced detailed, version-specific data models for all major QTI versions, with shared metadata and material structures.

* **Bug Fixes**
  * Updated parser logic to ensure QTI 3.0 documents are handled by a dedicated parser rather than reusing the QTI 2.1 parser.

* **Documentation**
  * Expanded and clarified the README to highlight version-specific architecture and maintainability improvements.

* **Refactor**
  * Simplified and modularized generic models, removing legacy definitions in favor of version-specific aliases and structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->